### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -136,6 +136,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_images, unit_test_images]
     timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Install Docker's Compose
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/donadiosolutions/scale-printer-mqtt/security/code-scanning/6](https://github.com/donadiosolutions/scale-printer-mqtt/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the `integration_test` job. This block should specify the least privileges required for the job to function correctly. Based on the job's actions, it primarily needs `contents: read` to access repository contents and `packages: read` to interact with the GitHub Container Registry.

The changes will be made in the `.github/workflows/build-test.yml` file, specifically within the `integration_test` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
