### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: Build and Test Daemons
+name: Build and test images
 
 on:
   push:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,6 +97,8 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     needs: [determine_platforms, build_images]
+    permissions:
+      contents: read
     strategy:
       matrix:
         daemon:


### PR DESCRIPTION
Potential fix for [https://github.com/donadiosolutions/scale-printer-mqtt/security/code-scanning/5](https://github.com/donadiosolutions/scale-printer-mqtt/security/code-scanning/5)

To fix the issue, add a `permissions` block to the `unit_test_images` job. Based on the job's functionality, it only needs to read repository contents to pull images and run tests. Therefore, the minimal permissions required are `contents: read`. This change ensures the job adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
