### PR TITLE
feat(actions): set explicit permissions for workflow jobs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,6 +17,7 @@ jobs:
   determine_platforms:
     name: Determine target platforms
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       platforms: ${{ steps.build_platforms.outputs.platforms }}
       platforms_for_display: ${{ steps.build_platforms.outputs.platforms_for_display }}
@@ -42,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine_platforms
     permissions:
+      contents: read
       packages: write
     strategy:
       matrix:
@@ -97,6 +99,9 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     needs: [determine_platforms, build_images]
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         daemon:


### PR DESCRIPTION
This commit updates the GitHub Actions workflows to explicitly define permissions for each job, adhering to the principle of least privilege.

Rationale for permissions in `.github/workflows/build-test.yml`:

- `determine_platforms` job:
  - `permissions: {}`
  - This job only determines build platforms based on environment variables and writes to GITHUB_OUTPUT. It does not require access to repository contents, packages, or any other GitHub resources. Setting empty permissions is the most restrictive and secure approach.

- `build_images` job:
  - `permissions: contents: read, packages: write`
  - `contents: read` is required for `actions/checkout@v4` to access the repository source code (including Dockerfiles).
  - `packages: write` is required for `docker/login-action@v3` to authenticate with GHCR and for `docker/build-push-action@v5` to push the built images to GitHub Container Registry.

- `unit_test_images` job:
  - `permissions: contents: read, packages: read`
  - `contents: read` is required for `actions/checkout@v4`.
  - `packages: read` is required for `docker/login-action@v3` to pull images from GHCR and for the subsequent `docker pull` and `docker run` commands that use these images.

- `integration_test` job:
  - `permissions: contents: read, packages: read` (No change from previous state)
  - `contents: read` is required for `actions/checkout@v4` and to read the `docker-compose.yml` file.
  - `packages: read` is required for `docker/login-action@v3` and for `docker compose up` to pull the necessary images from GHCR.

No changes were made to `.github/workflows/publish.yml` as its existing permissions (`contents: read, packages: write`) were already explicit and appropriate for its task of publishing images upon a release.