### PR TITLE
fix(gha): Align integration test with multi-arch strategy

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   integration_test:
     name: Run integration test with Compose
-    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || 'ubuntu-latest-arm64' }}
+    runs-on: ${{ (matrix.platform == 'linux/arm64' && 'ubuntu-latest-arm64') || 'ubuntu-latest' }}
     timeout-minutes: 5
     permissions:
       contents: read # No package:read permission needed
@@ -51,7 +51,6 @@ jobs:
         with:
           context: ./scale_daemon # Context needed for cache key resolution
           file: ./scale_daemon/Containerfile
-          platforms: ${{ matrix.platform }}
           target: final
           tags: scale-daemon:ci
           load: true # Load image into local Docker daemon from cache
@@ -63,7 +62,6 @@ jobs:
         with:
           context: ./printer_daemon # Context needed for cache key resolution
           file: ./printer_daemon/Containerfile
-          platforms: ${{ matrix.platform }}
           target: final
           tags: printer-daemon:ci
           load: true # Load image into local Docker daemon from cache

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -74,5 +74,5 @@ jobs:
       contents: read # Permissions for the token passed to the called workflow
     with:
       image_tag: ${{ inputs.image_tag }} # Use inputs from workflow_call
-      platforms: ${{ toJson(inputs.platforms) }} # Use inputs from workflow_call
+      platforms: ${{ inputs.platforms }} # Use inputs from workflow_call
     # secrets: inherit # If secrets need to be passed


### PR DESCRIPTION
This commit aligns the `integration-test.yml` workflow with the multi-architecture build strategy implemented in the other workflows.

**Workflow Fixes:**

- **Runner Selection**: The `runs-on` logic has been corrected to use native `ubuntu-latest-arm64` runners for `arm64` builds, ensuring that integration tests run on the appropriate architecture.
- **Docker Build Configuration**: The `docker/build-push-action` steps have been updated to remove the `platforms` input, which is incompatible with the `--load` option.
- **Workflow Dispatch**: The `unit-test.yml` workflow has been corrected to pass the `platforms` input as a raw string, ensuring that the `fromJson` function in the called workflow can correctly parse it.