### PR TITLE
fix(gha): Correct platform formatting in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           context: ${{ matrix.daemon.path }}
           file: ${{ matrix.daemon.path }}/Containerfile
-          platforms: ${{ fromJson(inputs.platforms) }} # Build for all platforms
+          platforms: ${{ join(fromJson(inputs.platforms), ',') }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit fixes a YAML syntax error in the `publish.yml` workflow that occurred because the `platforms` input was not being correctly formatted. The `docker/build-push-action` expects a comma-separated string, but it was receiving a JSON array string.

This has been resolved by using the `join` and `fromJson` functions to correctly format the `platforms` input, ensuring the workflow can execute successfully.